### PR TITLE
Introduce Cloud Custodian + GH Actions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,50 @@
+# This is a basic workflow to help you get started with Actions
+
+name: QA Custodian
+
+# Controls when the workflow will run
+on:
+  workflow_dispatch:
+    inputs:
+      testInput:
+        description: the test input
+        default: "manual_run"
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  build-and-run-cloud-custodian:
+    name: Run Cloud Custodian
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: install prerequisites
+        run: |
+          sudo apt-get update
+          sudo apt-get install python3-venv -y
+          python3 -m venv custodian
+          source custodian/bin/activate
+          pip install c7n
+          pip install c7n_azure
+          pip install c7n_gcp
+          pip install c7n-mailer
+      - name: update yaml files with user reserved names
+        env: 
+          USER_KEYS: ctw
+          DO_NOT_DELETE_KEYS: DO_NOT_DELETE
+        run: | 
+          date
+          cd qa-custodian
+          while read -r line; do export USER_KEYS="${USER_KEYS}|$line"; done < user-keys.txt
+          for i in `ls *.yaml`; do cat $i | sed -e 's/USERKEYS/'"$USER_KEYS"'/g' -i $i; done
+          while read -r line; do export DO_NOT_DELETE_KEYS="${DO_NOT_DELETE_KEYS}|$line"; done < do-not-delete-keys.txt
+          for i in `ls *.yaml`; do cat $i | sed -e 's/DONOTDELETEKEYS/'"$DO_NOT_DELETE_KEYS"'/g' -i $i; done
+      - name: run cloud custodian
+        env: 
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
+        run: |
+          source custodian/bin/activate
+          cd qa-custodian
+          cat nlb.yaml
+          while read -r line; do custodian run --output-dir=. --region=$line --dry-run nlb.yaml; done < regions.txt
+          while read -r line; do custodian run --output-dir=. --region=$line --dry-run instances.yaml; done < regions.txt

--- a/qa-custodian/README.md
+++ b/qa-custodian/README.md
@@ -1,0 +1,23 @@
+# QA Cloud Custodian
+
+[![QA Custodian](https://github.com/slickwarren/rancher-qa-tasks/actions/workflows/main.yaml/badge.svg)](https://github.com/slickwarren/rancher-qa-tasks/actions/workflows/main.yaml)
+
+QA custodian will clean up resources in AWS, GCR, and AZURE. Currently, we have:
+* AWS
+  * instances
+  * NLBs
+
+### Getting Started
+New Hires - make a PR adding one line to the `user-keys.txt` file. Use that key in ALL resources you create when using SUSE resources.  Keep it short (6 characters or less) unique to you, and recognizable by others (And, this is case sensitive!). For example, if your name was Melissa Di Donato, something like `mdd` would suffice. Just make sure you can remember it, and others can know who's it is if they are on your team. 
+
+### About the Automation
+This suite is setup to run with [Github Actions](https://docs.github.com/en/actions) on a cron schedule.  This is a free to use service, up to 2000 minutes of runtime per month. Navigate to this repo's `Actions` page, and click the latest run to view build info, logs, and more.
+##### Is It Secure?
+We use github secrets, which are only accessible to the maintainers (users with write access) of the repo.  However, just as with any other policy that is publically accessible, there are risks. We should be sure to never merge any code that outputs a secret.
+
+### About the Code
+This suite is fairly simple, and runs using [Cloud Custodian](https://cloud-custodian.github.io/cloud-custodian/docs/quickstart/index.html). Our modifications consist of the following:
+* text files
+  * `*-keys.txt` representing special keys that correspond with QA's resources
+  * `regions.txt` (AWS explicit) representing the regions we use on a regular basis, and therefore what the custodian will check against 
+* `.yaml` files, which are different configurations for the custodian to use when running. 

--- a/qa-custodian/do-not-delete-keys.txt
+++ b/qa-custodian/do-not-delete-keys.txt
@@ -1,0 +1,4 @@
+DONOTDELETE
+qahostedk3s
+qak3stenant
+DoNotDelete

--- a/qa-custodian/instances.yaml
+++ b/qa-custodian/instances.yaml
@@ -1,0 +1,46 @@
+policies:
+- name: delete-instances
+  resource: aws.ec2
+  filters:
+    - and:
+      - or: 
+        # instance name not in accepted user keys
+        - type: value
+          key: tag:Name
+          op: regex
+          #doesNOTcontain
+          value:  "^((?!USERKEYS).)*$"
+        # instance was tagged to delete yesterday
+        - 'tag:deletesAtMidnight': present
+      # instance is not doNotDelete
+      - not:
+        - 'tag:doNotDelete': present
+        - 'tag:DoNotDelete': present
+        - type: value
+          key: tag:Name
+          op: regex
+          value:  "^.*DONOTDELETEKEYS.*$"
+  actions:
+    - terminate
+
+- name: tag-day-old-instances
+  resource: aws.ec2
+  filters:
+    - and:
+      # instance is named with accepted user key
+      - type: value
+        key: tag:Name
+        op: regex
+        value:  "^.*USERKEYS.*$"
+      # instance is not doNotDelete
+      - not:
+        - 'tag:doNotDelete': present
+        - 'tag:DoNotDelete': present
+        - type: value
+          key: tag:Name
+          op: regex
+          value:  "^.*DONOTDELETEKEYS.*$"
+  actions:
+    - type: tag
+      tags:
+        deletesAtMidnight: ‘true'

--- a/qa-custodian/mailer.yaml
+++ b/qa-custodian/mailer.yaml
@@ -1,0 +1,3 @@
+queue_url: arn:aws:sqs:us-west-1:125601231307:rancherQAcustodian
+role: arn:aws:iam::125601231307:role/EngineeringUsersUS
+region: us-west-1

--- a/qa-custodian/nlb.yaml
+++ b/qa-custodian/nlb.yaml
@@ -1,0 +1,51 @@
+policies:
+- name: delete-nlbs
+  resource: app-elb
+  filters:
+    - and:
+      - or: 
+        - type: value
+          key: LoadBalancerArn
+          op: regex
+          value: "^((?!USERKEYS).)*$"
+        - 'tag:deletesAtMidnight': present
+      - not:
+        - 'tag:doNotDelete': present
+        - 'tag:DoNotDelete': present
+        - type: value
+          key: tag:Name
+          op: regex
+          value:  "^.*DONOTDELETEKEYS.*$"
+  actions:
+    - delete
+    ### option for notifying slack / via email (needs lambda permissions)
+    # - type: notify
+    #   slack_template: slack_default
+    #   slack_msg_color: danger
+    #   violation_desc: No violation.
+    #   action_desc: No action taken. 
+    #   to:
+    #     - https://hooks.slack.com/services/T0000000000/B000000000/XXXXXXXXXXXXXXX
+    #   transport:
+    #     type: sqs
+    #     queue: queue-url
+
+- name: tag-day-old-nlbs
+  resource: app-elb
+  filters:
+    - and:
+      - type: value
+        key: LoadBalancerArn
+        op: regex
+        value: "^.*USERKEYS.*$"
+      - not:
+        - 'tag:doNotDelete': present
+        - 'tag:DoNotDelete': present
+        - type: value
+          key: tag:Name
+          op: regex
+          value:  "^.*DONOTDELETEKEYS.*$"
+  actions:
+    - type: tag
+      tags:
+        deletesAtMidnight: ‘true'

--- a/qa-custodian/regions.txt
+++ b/qa-custodian/regions.txt
@@ -1,0 +1,4 @@
+us-east-1
+us-east-2
+us-west-1
+us-west-2

--- a/qa-custodian/user-keys.txt
+++ b/qa-custodian/user-keys.txt
@@ -1,0 +1,15 @@
+ctw
+anu
+sow
+bdp
+timhan
+jrm
+jkeslar
+hoffman
+das
+iz
+khush
+mew
+nick
+shy
+ugur


### PR DESCRIPTION
This PR introduces the use of cloud custodian, a tool that cleans our resources based on rules we define for it. Currently, the work done includes AWS instances and NLBs. In the future, we can add support for GCR and Azure, and extend AWS custodian support further. Please see the introduced README for more details.


This also introduces the use of github actions instead of managing an instance to run the infrastructure on. 

Everything in this PR is a proof of concept, so I have the following 'placeholders' until we decide on a definite route:
* GH action is not cron based yet, and can only be triggered manually
* the custodian is in `--dry-run` mode, meaning it will report the number of instances that would have been cleaned up, but not actually delete, tag, or take any action whatsoever

once we have decided if GH actions + the current cloud custodian ruleset works for us, we can submit a new PR amend these limits, run it on a regular (nightly) basis and actually rm resources on our behalf. 

note: upon opening this PR I noticed that I have merge permissions, which probably means that non-SUSE folks would too. The scope of permissions would need to be updated for this repo in order to keep our resources protected and secure.